### PR TITLE
Add python 3.11 to the tests and reduce version coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,7 @@ jobs:
       matrix:
         include:
           - python: "3.7"
-          - python: "3.8"
-          - python: "3.9"
-          - python: "3.10"
+          - python: "3.11"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = lint, mypy, py{37,38,39,310}
+# the versions specified here are overridden by github workflow
+envlist = lint, mypy, py{37,38,39,310,311}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
* Add python 3.11 to the test environnements
* Use only the oldest and latest versions for github workfkows