### PR TITLE
Add sync_standby as an acceptable state for a replica

### DIFF
--- a/check_patroni/cluster.py
+++ b/check_patroni/cluster.py
@@ -89,7 +89,7 @@ class ClusterHasReplica(PatroniResource):
         unhealthy_replica = 0
         for member in item_dict["members"]:
             # FIXME are there other acceptable states
-            if member["role"] == "replica":
+            if member["role"] == "replica" or member["role"] == "sync_standby":
                 if member["state"] == "running" and member["lag"] != "unknown":
                     replicas.append({"name": member["name"], "lag": member["lag"]})
                     if self.max_lag is None or self.max_lag >= int(member["lag"]):


### PR DESCRIPTION

Topology:

```
+ Cluster: DEtest --------+--------------+---------+-----+-----------+
| Member      | Host      | Role         | State   |  TL | Lag in MB |
+-------------+-----------+--------------+---------+-----+-----------+
| nodede002   | nodede002 | Leader       | running | 250 |           |
| + nodede001 | nodede001 | Sync Standby | running | 250 |         0 |
| + nodede003 | nodede003 | Replica      | running | 250 |         0 |
+-------------+-----------+--------------+---------+-----+-----------+
```

Checkoutput with added member role state:

```
CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;2:;1: unhealthy_replica=0 nodede001_lag=0 nodede003_lag=0
```