### PR TITLE
Fix the liveness check in node_is_alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add `sync_standby` as a valid replica type for `cluster_has_replica`. (contributed by @mattpoel)
 * Add a new service `cluster_has_scheduled_action` to warn of any scheduled switchover or restart.
+* Add options to `node_is_replica` to check specifically for a synchronous (`--is-sync`) or asynchronous node (`--is-async`).
 
 ### Fixed
 

--- a/check_patroni/types.py
+++ b/check_patroni/types.py
@@ -73,7 +73,7 @@ class PatroniResource(nagiosplugin.Resource):
                 return r.json()
             except requests.exceptions.JSONDecodeError:
                 return None
-        raise nagiosplugin.CheckError("Connection failed for all provided endpoints")
+        raise APIError("Connection failed for all provided endpoints")
 
 
 HandleUnknown = Callable[[nagiosplugin.Summary, nagiosplugin.Results], Any]


### PR DESCRIPTION
Previously if a node wasn't reachable whe would get an UNKNOWN error. instead of a CRITICAL error.

```
NODEISALIVE UNKNOWN - Connection failed for all provided endpoints
```

We now get the correct error.

```
NODEISALIVE CRITICAL - This node is not alive (patroni is not running). | is_alive=0;;@0
```