### PR TITLE
Revert d39122d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 ### Misc
 
-* Move packaging metadata into pyproject.toml 
 * Create CHANGELOG.md
 * Add tests for the output of the scripts in addition to the return code
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ check_patroni is licensed under PostgreSQL license.
 $ pip install git+https://github.com/dalibo/check_patroni.git
 ```
 
-Links:
-* [pip & centos 7](https://linuxize.com/post/how-to-install-pip-on-centos-7/)
-* [pip & debian10](https://linuxize.com/post/how-to-install-pip-on-debian-10/)
+check_patroni works on python 3.6, we keep it that way because patroni also
+supports it and there are still lots of RH 7 variants around. That being said
+python 3.6 has been EOL for age and there is no support for it in the github
+CI.
 
 ## Support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,62 +1,6 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "check_patroni"
-dynamic = ["version"]
-description = "Nagios plugin to check on patroni"
-readme = "README.md"
-license = { text = "PostgreSQL" }
-requires-python = ">=3.6"
-authors = [
-    { name = "Benoit Lobréau", email = "benoit.lobreau@dalibo.com" },
-    { name = "Dalibo", email = "contact@dalibo.com" },
-]
-maintainers = [
-    { name = "Benoit Lobréau", email = "benoit.lobreau@dalibo.com" },
-]
-keywords = [
-    "cli",
-    "monitoring",
-    "patroni",
-    "nagios",
-    "check",
-]
-classifiers = [
-    "Development Status :: 4 - Beta",   # "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "License :: OSI Approved :: PostgreSQL License",
-    "Programming Language :: Python :: 3",
-    "Topic :: System :: Monitoring",
-]
-dependencies = [
-    "attrs >= 17, !=21.1",
-    "requests",
-    "nagiosplugin >= 1.3.2",
-    "click >= 8.0.1",
-]
-
-[project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-mock",
-]
-
-[project.scripts]
-check_patroni = "check_patroni.cli:main"
-
-[project.urls]
-"Bug Tracker" = "https://github.com/dalibo/check_patroni/issues"
-Changelog = "https://github.com/dalibo/check_patroni/blob/master/CHANGELOG.md"
-Homepage = "https://github.com/dalibo/check_patroni"
-"Source code" = "https://github.com/dalibo/check_patroni"
-
-[tool.setuptools.dynamic]
-version = { attr = "check_patroni.__version__" }
-
-[tool.setuptools.packages.find]
-where = ["."]
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,59 @@
-from setuptools import setup
+import pathlib
 
-setup()
+from setuptools import find_packages, setup
+
+HERE = pathlib.Path(__file__).parent
+
+long_description = (HERE / "README.md").read_text()
+
+
+def get_version() -> str:
+    fpath = HERE / "check_patroni" / "__init__.py"
+    with fpath.open() as f:
+        for line in f:
+            if line.startswith("__version__"):
+                return line.split('"')[1]
+    raise Exception(f"version information not found in {fpath}")
+
+
+setup(
+    name="check_patroni",
+    version=get_version(),
+    author="Dalibo",
+    author_email="contact@dalibo.com",
+    packages=find_packages(include=["check_patroni*"]),
+    include_package_data=True,
+    url="https://github.com/dalibo/check_patroni",
+    license="PostgreSQL",
+    description="Nagios plugin to check on patroni",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Development Status :: 4 - Beta",  # "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "License :: OSI Approved :: PostgreSQL License",
+        "Programming Language :: Python :: 3",
+        "Topic :: System :: Monitoring",
+    ],
+    keywords="patroni nagios check",
+    python_requires=">=3.6",
+    install_requires=[
+        "attrs >= 17, !=21.1",
+        "requests",
+        "nagiosplugin >= 1.3.2",
+        "click >= 8.0.1",
+    ],
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-mock",
+        ],
+    },
+    entry_points={
+        "console_scripts": [
+            "check_patroni=check_patroni.cli:main",
+        ],
+    },
+    zip_safe=False,
+)
+


### PR DESCRIPTION
This changes requiered python 3.7 which I overlooked at first. I would
like to be able to install the check any patroni server and Patroni
supports python 3.6.