### PR TITLE
Add info and options about sync standby to cluster_has_replica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Add `sync_standby` as a valid replica type for `cluster_has_replica`. (contributed by @mattpoel)
+* Add info and options (`--sync-warning` and `--sync-critical`) about sync replica to `cluster_has_replica`.
 * Add a new service `cluster_has_scheduled_action` to warn of any scheduled switchover or restart.
 * Add options to `node_is_replica` to check specifically for a synchronous (`--is-sync`) or asynchronous node (`--is-async`).
 * Add `standby-leader` as a valid leader type for `cluster_has_leader`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
 Commands:
   cluster_config_has_changed    Check if the hash of the configuration...
   cluster_has_leader            Check if the cluster has a leader.
-  cluster_has_replica           Check if the cluster has healthy replicas.
+  cluster_has_replica           Check if the cluster has healthy replicas...
   cluster_has_scheduled_action  Check if the cluster has a scheduled...
   cluster_is_in_maintenance     Check if the cluster is in maintenance...
   cluster_node_count            Count the number of nodes in the cluster.
@@ -222,7 +222,7 @@ Options:
 ```
 Usage: check_patroni cluster_has_replica [OPTIONS]
 
-  Check if the cluster has healthy replicas.
+  Check if the cluster has healthy replicas and/or if some are sync standbies
 
   A healthy replica:
   * is in running or streaming state (V3.0.4)
@@ -231,19 +231,24 @@ Usage: check_patroni cluster_has_replica [OPTIONS]
 
   Check:
   * `OK`: if the healthy_replica count and their lag are compatible with the replica count threshold.
+          and if the sync_replica count is compatible with the sync replica count threshold.
   * `WARNING` / `CRITICAL`: otherwise
 
   Perfdata:
   * healthy_replica & unhealthy_replica count
+  * the number of sync_replica, they are included in the previous count
   * the lag of each replica labelled with  "member name"_lag
+  * a boolean to tell if the node is a sync stanbdy labelled with  "member name"_sync
 
 Options:
-  -w, --warning TEXT   Warning threshold for the number of healthy replica
-                       nodes.
-  -c, --critical TEXT  Critical threshold for the number of healthy replica
-                       nodes.
-  --max-lag TEXT       maximum allowed lag
-  --help               Show this message and exit.
+  -w, --warning TEXT    Warning threshold for the number of healthy replica
+                        nodes.
+  -c, --critical TEXT   Critical threshold for the number of healthy replica
+                        nodes.
+  --sync-warning TEXT   Warning threshold for the number of sync replica.
+  --sync-critical TEXT  Critical threshold for the number of sync replica.
+  --max-lag TEXT        maximum allowed lag
+  --help                Show this message and exit.
 ```
 
 ### cluster_has_scheduled_action

--- a/tests/test_cluster_has_replica.py
+++ b/tests/test_cluster_has_replica.py
@@ -19,7 +19,7 @@ def test_cluster_has_relica_ok(
     assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv3_lag=0 unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv2_sync=0 srv3_lag=0 srv3_sync=1 sync_replica=1 unhealthy_replica=0\n"
     )
 
 
@@ -44,7 +44,30 @@ def test_cluster_has_replica_ok_with_count_thresholds(
     assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=0 srv3_lag=0 unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=0 srv2_sync=0 srv3_lag=0 srv3_sync=1 sync_replica=1 unhealthy_replica=0\n"
+    )
+
+
+def test_cluster_has_replica_ok_with_sync_count_thresholds(
+    mocker: MockerFixture, use_old_replica_state: bool
+) -> None:
+    runner = CliRunner()
+
+    my_mock(mocker, "cluster_has_replica_ok", 200, use_old_replica_state)
+    result = runner.invoke(
+        main,
+        [
+            "-e",
+            "https://10.20.199.3:8008",
+            "cluster_has_replica",
+            "--sync-warning",
+            "1:",
+        ],
+    )
+    assert result.exit_code == 0
+    assert (
+        result.stdout
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv2_sync=0 srv3_lag=0 srv3_sync=1 sync_replica=1;1: unhealthy_replica=0\n"
     )
 
 
@@ -72,7 +95,7 @@ def test_cluster_has_replica_ok_with_count_thresholds_lag(
     assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=1024 srv3_lag=0 unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=1024 srv2_sync=0 srv3_lag=0 srv3_sync=0 sync_replica=0 unhealthy_replica=0\n"
     )
 
 
@@ -97,7 +120,32 @@ def test_cluster_has_replica_ko_with_count_thresholds(
     assert result.exit_code == 1
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA WARNING - healthy_replica is 1 (outside range @0:1) | healthy_replica=1;@1;@0 srv3_lag=0 unhealthy_replica=1\n"
+        == "CLUSTERHASREPLICA WARNING - healthy_replica is 1 (outside range @0:1) | healthy_replica=1;@1;@0 srv3_lag=0 srv3_sync=0 sync_replica=0 unhealthy_replica=1\n"
+    )
+
+
+def test_cluster_has_replica_ko_with_sync_count_thresholds(
+    mocker: MockerFixture, use_old_replica_state: bool
+) -> None:
+    runner = CliRunner()
+
+    my_mock(mocker, "cluster_has_replica_ko", 200, use_old_replica_state)
+    result = runner.invoke(
+        main,
+        [
+            "-e",
+            "https://10.20.199.3:8008",
+            "cluster_has_replica",
+            "--sync-warning",
+            "2:",
+            "--sync-critical",
+            "1:",
+        ],
+    )
+    assert result.exit_code == 2
+    assert (
+        result.stdout
+        == "CLUSTERHASREPLICA CRITICAL - sync_replica is 0 (outside range 1:) | healthy_replica=1 srv3_lag=0 srv3_sync=0 sync_replica=0;2:;1: unhealthy_replica=1\n"
     )
 
 
@@ -125,5 +173,5 @@ def test_cluster_has_replica_ko_with_count_thresholds_and_lag(
     assert result.exit_code == 2
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA CRITICAL - healthy_replica is 0 (outside range @0:0) | healthy_replica=0;@1;@0 srv2_lag=10241024 srv3_lag=20000000 unhealthy_replica=2\n"
+        == "CLUSTERHASREPLICA CRITICAL - healthy_replica is 0 (outside range @0:0) | healthy_replica=0;@1;@0 srv2_lag=10241024 srv2_sync=0 srv3_lag=20000000 srv3_sync=0 sync_replica=0 unhealthy_replica=2\n"
     )


### PR DESCRIPTION
* Add `--sync-warning` and `--sync-critical`
* Add `sync_replica` to track the number of sync replica in the perf data
* Add `MEMBER-sync` to track if a member is a sync replica in the perf data