### PR TITLE
cluster_has_replica: fix the way a healthy replica is detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ### Added
 
+* Add the timeline in the  `cluster_has_replica` perfstats. (#50)
+
 ### Fixed
 
 * Add compatibility with [requests](https://requests.readthedocs.io)
   version 2.25 and higher.
+* Fix what `cluster_has_replica` deems a healthy replica. (#50, reported by @mbanck)
+* Fix `cluster_has_replica` to display perfstats for replicas whenever it's possible (healthy or not). (#50)
 
 ### Misc
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,12 +50,13 @@ class PatroniAPI(HTTPServer):
 
 
 def cluster_api_set_replica_running(in_json: Path, target_dir: Path) -> Path:
-    # starting from 3.0.4 the state of replicas is streaming instead of running
+    # starting from 3.0.4 the state of replicas is streaming or in archive recovery
+    # instead of running
     with in_json.open() as f:
         js = json.load(f)
     for node in js["members"]:
         if node["role"] in ["replica", "sync_standby"]:
-            if node["state"] == "streaming":
+            if node["state"] in ["streaming", "in archive recovery"]:
                 node["state"] = "running"
     assert target_dir.is_dir()
     out_json = target_dir / in_json.name

--- a/tests/json/cluster_has_replica_ko_all_replica.json
+++ b/tests/json/cluster_has_replica_ko_all_replica.json
@@ -2,17 +2,18 @@
   "members": [
     {
       "name": "srv1",
-      "role": "leader",
+      "role": "replica",
       "state": "running",
       "api_url": "https://10.20.199.3:8008/patroni",
       "host": "10.20.199.3",
       "port": 5432,
-      "timeline": 51
+      "timeline": 51,
+      "lag": 0
     },
     {
       "name": "srv2",
       "role": "replica",
-      "state": "in archive recovery",
+      "state": "running",
       "api_url": "https://10.20.199.4:8008/patroni",
       "host": "10.20.199.4",
       "port": 5432,
@@ -21,13 +22,14 @@
     },
     {
       "name": "srv3",
-      "role": "sync_standby",
-      "state": "streaming",
+      "role": "replica",
+      "state": "running",
       "api_url": "https://10.20.199.5:8008/patroni",
       "host": "10.20.199.5",
       "port": 5432,
       "timeline": 51,
       "lag": 0
+
     }
   ]
 }

--- a/tests/json/cluster_has_replica_ko_wrong_tl.json
+++ b/tests/json/cluster_has_replica_ko_wrong_tl.json
@@ -12,16 +12,16 @@
     {
       "name": "srv2",
       "role": "replica",
-      "state": "in archive recovery",
+      "state": "running",
       "api_url": "https://10.20.199.4:8008/patroni",
       "host": "10.20.199.4",
       "port": 5432,
-      "timeline": 51,
-      "lag": 0
+      "timeline": 50,
+      "lag": 1000000
     },
     {
       "name": "srv3",
-      "role": "sync_standby",
+      "role": "replica",
       "state": "streaming",
       "api_url": "https://10.20.199.5:8008/patroni",
       "host": "10.20.199.5",

--- a/tests/json/cluster_has_replica_patroni_verion_3.0.0.json
+++ b/tests/json/cluster_has_replica_patroni_verion_3.0.0.json
@@ -1,0 +1,26 @@
+{
+  "state": "running",
+  "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
+  "role": "master",
+  "server_version": 110012,
+  "cluster_unlocked": false,
+  "xlog": {
+    "location": 1174407088
+  },
+  "timeline": 51,
+  "replication": [
+    {
+      "usename": "replicator",
+      "application_name": "srv1",
+      "client_addr": "10.20.199.3",
+      "state": "streaming",
+      "sync_state": "async",
+      "sync_priority": 0
+    }
+  ],
+  "database_system_identifier": "6965971025273547206",
+  "patroni": {
+    "version": "3.0.0",
+    "scope": "patroni-demo"
+  }
+}

--- a/tests/json/cluster_has_replica_patroni_verion_3.1.0.json
+++ b/tests/json/cluster_has_replica_patroni_verion_3.1.0.json
@@ -1,0 +1,26 @@
+{
+  "state": "running",
+  "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
+  "role": "master",
+  "server_version": 110012,
+  "cluster_unlocked": false,
+  "xlog": {
+    "location": 1174407088
+  },
+  "timeline": 51,
+  "replication": [
+    {
+      "usename": "replicator",
+      "application_name": "srv1",
+      "client_addr": "10.20.199.3",
+      "state": "streaming",
+      "sync_state": "async",
+      "sync_priority": 0
+    }
+  ],
+  "database_system_identifier": "6965971025273547206",
+  "patroni": {
+    "version": "3.1.0",
+    "scope": "patroni-demo"
+  }
+}

--- a/tests/test_cluster_has_replica.py
+++ b/tests/test_cluster_has_replica.py
@@ -13,22 +13,23 @@ from . import PatroniAPI, cluster_api_set_replica_running
 def cluster_has_replica_ok(
     patroni_api: PatroniAPI, old_replica_state: bool, datadir: Path, tmp_path: Path
 ) -> Iterator[None]:
-    path: Union[str, Path] = "cluster_has_replica_ok.json"
+    cluster_path: Union[str, Path] = "cluster_has_replica_ok.json"
+    patroni_path = "cluster_has_replica_patroni_verion_3.1.0.json"
     if old_replica_state:
-        path = cluster_api_set_replica_running(datadir / path, tmp_path)
-    with patroni_api.routes({"cluster": path}):
+        cluster_path = cluster_api_set_replica_running(datadir / cluster_path, tmp_path)
+        patroni_path = "cluster_has_replica_patroni_verion_3.0.0.json"
+    with patroni_api.routes({"cluster": cluster_path, "patroni": patroni_path}):
         yield None
 
 
-# TODO Lag threshold tests
 @pytest.mark.usefixtures("cluster_has_replica_ok")
 def test_cluster_has_relica_ok(runner: CliRunner, patroni_api: PatroniAPI) -> None:
     result = runner.invoke(main, ["-e", patroni_api.endpoint, "cluster_has_replica"])
-    assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv2_sync=0 srv3_lag=0 srv3_sync=1 sync_replica=1 unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv2_sync=0 srv2_timeline=51 srv3_lag=0 srv3_sync=1 srv3_timeline=51 sync_replica=1 unhealthy_replica=0\n"
     )
+    assert result.exit_code == 0
 
 
 @pytest.mark.usefixtures("cluster_has_replica_ok")
@@ -47,11 +48,11 @@ def test_cluster_has_replica_ok_with_count_thresholds(
             "@0",
         ],
     )
-    assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=0 srv2_sync=0 srv3_lag=0 srv3_sync=1 sync_replica=1 unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=0 srv2_sync=0 srv2_timeline=51 srv3_lag=0 srv3_sync=1 srv3_timeline=51 sync_replica=1 unhealthy_replica=0\n"
     )
+    assert result.exit_code == 0
 
 
 @pytest.mark.usefixtures("cluster_has_replica_ok")
@@ -68,21 +69,23 @@ def test_cluster_has_replica_ok_with_sync_count_thresholds(
             "1:",
         ],
     )
-    assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv2_sync=0 srv3_lag=0 srv3_sync=1 sync_replica=1;1: unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2 srv2_lag=0 srv2_sync=0 srv2_timeline=51 srv3_lag=0 srv3_sync=1 srv3_timeline=51 sync_replica=1;1: unhealthy_replica=0\n"
     )
+    assert result.exit_code == 0
 
 
 @pytest.fixture
 def cluster_has_replica_ok_lag(
     patroni_api: PatroniAPI, datadir: Path, tmp_path: Path, old_replica_state: bool
 ) -> Iterator[None]:
-    path: Union[str, Path] = "cluster_has_replica_ok_lag.json"
+    cluster_path: Union[str, Path] = "cluster_has_replica_ok_lag.json"
+    patroni_path = "cluster_has_replica_patroni_verion_3.1.0.json"
     if old_replica_state:
-        path = cluster_api_set_replica_running(datadir / path, tmp_path)
-    with patroni_api.routes({"cluster": path}):
+        cluster_path = cluster_api_set_replica_running(datadir / cluster_path, tmp_path)
+        patroni_path = "cluster_has_replica_patroni_verion_3.0.0.json"
+    with patroni_api.routes({"cluster": cluster_path, "patroni": patroni_path}):
         yield None
 
 
@@ -104,21 +107,23 @@ def test_cluster_has_replica_ok_with_count_thresholds_lag(
             "1MB",
         ],
     )
-    assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=1024 srv2_sync=0 srv3_lag=0 srv3_sync=0 sync_replica=0 unhealthy_replica=0\n"
+        == "CLUSTERHASREPLICA OK - healthy_replica is 2 | healthy_replica=2;@1;@0 srv2_lag=1024 srv2_sync=0 srv2_timeline=51 srv3_lag=0 srv3_sync=0 srv3_timeline=51 sync_replica=0 unhealthy_replica=0\n"
     )
+    assert result.exit_code == 0
 
 
 @pytest.fixture
 def cluster_has_replica_ko(
     patroni_api: PatroniAPI, old_replica_state: bool, datadir: Path, tmp_path: Path
 ) -> Iterator[None]:
-    path: Union[str, Path] = "cluster_has_replica_ko.json"
+    cluster_path: Union[str, Path] = "cluster_has_replica_ko.json"
+    patroni_path: Union[str, Path] = "cluster_has_replica_patroni_verion_3.1.0.json"
     if old_replica_state:
-        path = cluster_api_set_replica_running(datadir / path, tmp_path)
-    with patroni_api.routes({"cluster": path}):
+        cluster_path = cluster_api_set_replica_running(datadir / cluster_path, tmp_path)
+        patroni_path = "cluster_has_replica_patroni_verion_3.0.0.json"
+    with patroni_api.routes({"cluster": cluster_path, "patroni": patroni_path}):
         yield None
 
 
@@ -138,11 +143,11 @@ def test_cluster_has_replica_ko_with_count_thresholds(
             "@0",
         ],
     )
-    assert result.exit_code == 1
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA WARNING - healthy_replica is 1 (outside range @0:1) | healthy_replica=1;@1;@0 srv3_lag=0 srv3_sync=0 sync_replica=0 unhealthy_replica=1\n"
+        == "CLUSTERHASREPLICA WARNING - healthy_replica is 1 (outside range @0:1) | healthy_replica=1;@1;@0 srv3_lag=0 srv3_sync=0 srv3_timeline=51 sync_replica=0 unhealthy_replica=1\n"
     )
+    assert result.exit_code == 1
 
 
 @pytest.mark.usefixtures("cluster_has_replica_ko")
@@ -161,21 +166,24 @@ def test_cluster_has_replica_ko_with_sync_count_thresholds(
             "1:",
         ],
     )
-    assert result.exit_code == 2
+    # The lag on srv2 is "unknown". We don't handle string in perfstats so we have to scratch all the second node stats
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA CRITICAL - sync_replica is 0 (outside range 1:) | healthy_replica=1 srv3_lag=0 srv3_sync=0 sync_replica=0;2:;1: unhealthy_replica=1\n"
+        == "CLUSTERHASREPLICA CRITICAL - sync_replica is 0 (outside range 1:) | healthy_replica=1 srv3_lag=0 srv3_sync=0 srv3_timeline=51 sync_replica=0;2:;1: unhealthy_replica=1\n"
     )
+    assert result.exit_code == 2
 
 
 @pytest.fixture
 def cluster_has_replica_ko_lag(
     patroni_api: PatroniAPI, old_replica_state: bool, datadir: Path, tmp_path: Path
 ) -> Iterator[None]:
-    path: Union[str, Path] = "cluster_has_replica_ko_lag.json"
+    cluster_path: Union[str, Path] = "cluster_has_replica_ko_lag.json"
+    patroni_path = "cluster_has_replica_patroni_verion_3.1.0.json"
     if old_replica_state:
-        path = cluster_api_set_replica_running(datadir / path, tmp_path)
-    with patroni_api.routes({"cluster": path}):
+        cluster_path = cluster_api_set_replica_running(datadir / cluster_path, tmp_path)
+        patroni_path = "cluster_has_replica_patroni_verion_3.0.0.json"
+    with patroni_api.routes({"cluster": cluster_path, "patroni": patroni_path}):
         yield None
 
 
@@ -197,8 +205,84 @@ def test_cluster_has_replica_ko_with_count_thresholds_and_lag(
             "1MB",
         ],
     )
-    assert result.exit_code == 2
     assert (
         result.stdout
-        == "CLUSTERHASREPLICA CRITICAL - healthy_replica is 0 (outside range @0:0) | healthy_replica=0;@1;@0 srv2_lag=10241024 srv2_sync=0 srv3_lag=20000000 srv3_sync=0 sync_replica=0 unhealthy_replica=2\n"
+        == "CLUSTERHASREPLICA CRITICAL - healthy_replica is 0 (outside range @0:0) | healthy_replica=0;@1;@0 srv2_lag=10241024 srv2_sync=0 srv2_timeline=51 srv3_lag=20000000 srv3_sync=0 srv3_timeline=51 sync_replica=0 unhealthy_replica=2\n"
     )
+    assert result.exit_code == 2
+
+
+@pytest.fixture
+def cluster_has_replica_ko_wrong_tl(
+    patroni_api: PatroniAPI, old_replica_state: bool, datadir: Path, tmp_path: Path
+) -> Iterator[None]:
+    cluster_path: Union[str, Path] = "cluster_has_replica_ko_wrong_tl.json"
+    patroni_path = "cluster_has_replica_patroni_verion_3.1.0.json"
+    if old_replica_state:
+        cluster_path = cluster_api_set_replica_running(datadir / cluster_path, tmp_path)
+        patroni_path = "cluster_has_replica_patroni_verion_3.0.0.json"
+    with patroni_api.routes({"cluster": cluster_path, "patroni": patroni_path}):
+        yield None
+
+
+@pytest.mark.usefixtures("cluster_has_replica_ko_wrong_tl")
+def test_cluster_has_replica_ko_wrong_tl(
+    runner: CliRunner, patroni_api: PatroniAPI
+) -> None:
+    result = runner.invoke(
+        main,
+        [
+            "-e",
+            patroni_api.endpoint,
+            "cluster_has_replica",
+            "--warning",
+            "@1",
+            "--critical",
+            "@0",
+            "--max-lag",
+            "1MB",
+        ],
+    )
+    assert (
+        result.stdout
+        == "CLUSTERHASREPLICA WARNING - healthy_replica is 1 (outside range @0:1) | healthy_replica=1;@1;@0 srv2_lag=1000000 srv2_sync=0 srv2_timeline=50 srv3_lag=0 srv3_sync=0 srv3_timeline=51 sync_replica=0 unhealthy_replica=1\n"
+    )
+    assert result.exit_code == 1
+
+
+@pytest.fixture
+def cluster_has_replica_ko_all_replica(
+    patroni_api: PatroniAPI, old_replica_state: bool, datadir: Path, tmp_path: Path
+) -> Iterator[None]:
+    cluster_path: Union[str, Path] = "cluster_has_replica_ko_all_replica.json"
+    patroni_path = "cluster_has_replica_patroni_verion_3.1.0.json"
+    if old_replica_state:
+        cluster_path = cluster_api_set_replica_running(datadir / cluster_path, tmp_path)
+        patroni_path = "cluster_has_replica_patroni_verion_3.0.0.json"
+    with patroni_api.routes({"cluster": cluster_path, "patroni": patroni_path}):
+        yield None
+
+
+@pytest.mark.usefixtures("cluster_has_replica_ko_all_replica")
+def test_cluster_has_replica_ko_all_replica(
+    runner: CliRunner, patroni_api: PatroniAPI
+) -> None:
+    result = runner.invoke(
+        main,
+        [
+            "-e",
+            patroni_api.endpoint,
+            "cluster_has_replica",
+            "--warning",
+            "@1",
+            "--critical",
+            "@0",
+            "--max-lag",
+            "1MB",
+        ],
+    )
+    assert (
+        result.stdout
+        == "CLUSTERHASREPLICA CRITICAL - healthy_replica is 0 (outside range @0:0) | healthy_replica=0;@1;@0 srv1_lag=0 srv1_sync=0 srv1_timeline=51 srv2_lag=0 srv2_sync=0 srv2_timeline=51 srv3_lag=0 srv3_sync=0 srv3_timeline=51 sync_replica=0 unhealthy_replica=3\n"
+    )
+    assert result.exit_code == 2


### PR DESCRIPTION
For patroni >= version 3.0.4:
* the role is replica or sync_standby
* the state is streaming
* the lag is lower or equal to max_lag

For prio versions:
* the role is replica or sync_standby
* the state is running and with the same timeline has the leader
* the lag is lower or equal to max_lag