### PR TITLE
compat. with old Python libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   by @dlax).
 * Work around old pytest versions in type annotations in the test suite.
 * Declare compatibility with click version 7.1 (or higher).
+* In tests, work around nagiosplugin 1.3.2 not properly handling stdout
+  redirection.
 
 ## check_patroni 1.0.0 - 2023-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+* Add compatibility with [requests](https://requests.readthedocs.io)
+  version 2.25 and higher.
+
 ### Misc
 
 * Improve test coverage by running an HTTP server to fake the Patroni API (#55

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Improve test coverage by running an HTTP server to fake the Patroni API (#55
   by @dlax).
+* Declare compatibility with click version 7.1 (or higher).
 
 ## check_patroni 1.0.0 - 2023-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Improve test coverage by running an HTTP server to fake the Patroni API (#55
   by @dlax).
+* Work around old pytest versions in type annotations in the test suite.
 * Declare compatibility with click version 7.1 (or higher).
 
 ## check_patroni 1.0.0 - 2023-08-28

--- a/check_patroni/types.py
+++ b/check_patroni/types.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Callable, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
@@ -71,7 +72,7 @@ class PatroniResource(nagiosplugin.Resource):
 
             try:
                 return r.json()
-            except requests.exceptions.JSONDecodeError:
+            except (json.JSONDecodeError, ValueError):
                 return None
         raise nagiosplugin.CheckError("Connection failed for all provided endpoints")
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     ],
     extras_require={
         "test": [
-            "pytest",
+            "importlib_metadata; python_version < '3.8'",
+            "pytest >= 6.0.2",
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "attrs >= 17, !=21.1",
         "requests",
         "nagiosplugin >= 1.3.2",
-        "click >= 8.0.1",
+        "click >= 7.1",
     ],
     extras_require={
         "test": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,28 @@
+import sys
 from pathlib import Path
 from threading import Thread
-from typing import Any, Iterator
+from typing import Any, Iterator, Tuple
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version as metadata_version
+else:
+    from importlib_metadata import version as metadata_version
 
 import pytest
 from click.testing import CliRunner
 
 from . import PatroniAPI
+
+
+def numversion(pkgname: str) -> Tuple[int, ...]:
+    version = metadata_version(pkgname)
+    return tuple(int(v) for v in version.split(".", 3))
+
+
+if numversion("pytest") >= (6, 2):
+    TempPathFactory = pytest.TempPathFactory
+else:
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(
@@ -23,7 +40,7 @@ def datadir() -> Path:
 
 @pytest.fixture(scope="session")
 def patroni_api(
-    tmp_path_factory: pytest.TempPathFactory, datadir: Path
+    tmp_path_factory: TempPathFactory, datadir: Path
 ) -> Iterator[PatroniAPI]:
     """A fake HTTP server for the Patroni API serving files from a temporary
     directory.


### PR DESCRIPTION
The test suite now passes on these old platforms:

- [debian/bullseye](https://builds.sr.ht/~dlax/job/1069714)
- [ubuntu/focal](https://builds.sr.ht/~dlax/job/1069713)