### PR TITLE
Update check_patroni for patroni 4.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 check_patroni.egg-info
 tests/config.ini
+tests/*.state_file
 vagrant/.vagrant
 vagrant/*.state_file
 .*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change log
 
+## Unreleased
+
+### Misc
+
+* Update the tests and the documentation to reflect that master is replaced by
+  primary everywhere it's visible in Patroni. We didn't use the term so there
+  is nothing to change in our code.
+
 ## check_patroni 2.0.0 - 2024-04-29
 
 ### Notice

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Usage: check_patroni cluster_node_count [OPTIONS]
 
   The role refers to the role of the server in the cluster. Possible values
   are:
-  * master or leader
+  * leader (master was removed in patroni 4.0.0)
   * replica
   * standby_leader
   * sync_standby

--- a/check_patroni/cli.py
+++ b/check_patroni/cli.py
@@ -229,7 +229,7 @@ def cluster_node_count(
     \b
     The role refers to the role of the server in the cluster. Possible values
     are:
-    * master or leader
+    * leader (master was removed in patroni 4.0.0)
     * replica
     * standby_leader
     * sync_standby

--- a/tests/json/cluster_config_has_changed.json
+++ b/tests/json/cluster_config_has_changed.json
@@ -1,6 +1,6 @@
 {
   "loop_wait": 10,
-  "master_start_timeout": 300,
+  "primary_start_timeout": 300,
   "postgresql": {
     "parameters": {
       "archive_command": "pgbackrest --stanza=main archive-push %p",

--- a/tests/json/cluster_has_replica_patroni_verion_3.0.0.json
+++ b/tests/json/cluster_has_replica_patroni_verion_3.0.0.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/cluster_has_replica_patroni_verion_3.1.0.json
+++ b/tests/json/cluster_has_replica_patroni_verion_3.1.0.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_is_leader_ko.json
+++ b/tests/json/node_is_leader_ko.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_is_leader_ok.json
+++ b/tests/json/node_is_leader_ok.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_is_pending_restart_ko.json
+++ b/tests/json/node_is_pending_restart_ko.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_is_pending_restart_ok.json
+++ b/tests/json/node_is_pending_restart_ok.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_is_primary_ok.json
+++ b/tests/json/node_is_primary_ok.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_is_replica_ko.json
+++ b/tests/json/node_is_replica_ko.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_patroni_version.json
+++ b/tests/json/node_patroni_version.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/json/node_tl_has_changed.json
+++ b/tests/json/node_tl_has_changed.json
@@ -1,7 +1,7 @@
 {
   "state": "running",
   "postmaster_start_time": "2021-08-11 07:02:20.732 UTC",
-  "role": "master",
+  "role": "primary",
   "server_version": 110012,
   "cluster_unlocked": false,
   "xlog": {

--- a/tests/test_cluster_config_has_changed.py
+++ b/tests/test_cluster_config_has_changed.py
@@ -26,14 +26,14 @@ def test_cluster_config_has_changed_ok_with_hash(
             patroni_api.endpoint,
             "cluster_config_has_changed",
             "--hash",
-            "96b12d82571473d13e890b893734e731",
+            "30022c301991e7395182b1134683e518",
         ],
     )
-    assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERCONFIGHASCHANGED OK - The hash of patroni's dynamic configuration has not changed (96b12d82571473d13e890b893734e731). | is_configuration_changed=0;;@1:1\n"
+        == "CLUSTERCONFIGHASCHANGED OK - The hash of patroni's dynamic configuration has not changed (30022c301991e7395182b1134683e518). | is_configuration_changed=0;;@1:1\n"
     )
+    assert result.exit_code == 0
 
 
 def test_cluster_config_has_changed_ok_with_state_file(
@@ -41,7 +41,7 @@ def test_cluster_config_has_changed_ok_with_state_file(
 ) -> None:
     state_file = tmp_path / "cluster_config_has_changed.state_file"
     with state_file.open("w") as f:
-        f.write('{"hash": "96b12d82571473d13e890b893734e731"}')
+        f.write('{"hash": "30022c301991e7395182b1134683e518"}')
 
     result = runner.invoke(
         main,
@@ -53,11 +53,11 @@ def test_cluster_config_has_changed_ok_with_state_file(
             str(state_file),
         ],
     )
-    assert result.exit_code == 0
     assert (
         result.stdout
-        == "CLUSTERCONFIGHASCHANGED OK - The hash of patroni's dynamic configuration has not changed (96b12d82571473d13e890b893734e731). | is_configuration_changed=0;;@1:1\n"
+        == "CLUSTERCONFIGHASCHANGED OK - The hash of patroni's dynamic configuration has not changed (30022c301991e7395182b1134683e518). | is_configuration_changed=0;;@1:1\n"
     )
+    assert result.exit_code == 0
 
 
 def test_cluster_config_has_changed_ko_with_hash(
@@ -73,11 +73,11 @@ def test_cluster_config_has_changed_ko_with_hash(
             "96b12d82571473d13e890b8937ffffff",
         ],
     )
-    assert result.exit_code == 2
     assert (
         result.stdout
         == "CLUSTERCONFIGHASCHANGED CRITICAL - The hash of patroni's dynamic configuration has changed. The old hash was 96b12d82571473d13e890b8937ffffff. | is_configuration_changed=1;;@1:1\n"
     )
+    assert result.exit_code == 2
 
 
 def test_cluster_config_has_changed_ko_with_state_file_and_save(
@@ -98,11 +98,11 @@ def test_cluster_config_has_changed_ko_with_state_file_and_save(
             str(state_file),
         ],
     )
-    assert result.exit_code == 2
     assert (
         result.stdout
         == "CLUSTERCONFIGHASCHANGED CRITICAL - The hash of patroni's dynamic configuration has changed. The old hash was 96b12d82571473d13e890b8937ffffff. | is_configuration_changed=1;;@1:1\n"
     )
+    assert result.exit_code == 2
 
     state_file = tmp_path / "cluster_config_has_changed.state_file"
     cookie = nagiosplugin.Cookie(state_file)
@@ -124,18 +124,18 @@ def test_cluster_config_has_changed_ko_with_state_file_and_save(
             "--save",
         ],
     )
-    assert result.exit_code == 2
     assert (
         result.stdout
         == "CLUSTERCONFIGHASCHANGED CRITICAL - The hash of patroni's dynamic configuration has changed. The old hash was 96b12d82571473d13e890b8937ffffff. | is_configuration_changed=1;;@1:1\n"
     )
+    assert result.exit_code == 2
 
     cookie = nagiosplugin.Cookie(state_file)
     cookie.open()
     new_config_hash = cookie.get("hash")
     cookie.close()
 
-    assert new_config_hash == "96b12d82571473d13e890b893734e731"
+    assert new_config_hash == "30022c301991e7395182b1134683e518"
 
 
 def test_cluster_config_has_changed_params(
@@ -155,16 +155,15 @@ def test_cluster_config_has_changed_params(
             str(fake_state_file),
         ],
     )
-    assert result.exit_code == 3
     assert (
         result.stdout
         == "CLUSTERCONFIGHASCHANGED UNKNOWN: click.exceptions.UsageError: Either --hash or --state-file should be provided for this service\n"
     )
+    assert result.exit_code == 3
 
     result = runner.invoke(
         main, ["-e", "https://10.20.199.3:8008", "cluster_config_has_changed"]
     )
-    assert result.exit_code == 3
     assert (
         result.stdout
         == "CLUSTERCONFIGHASCHANGED UNKNOWN: click.exceptions.UsageError: Either --hash or --state-file should be provided for this service\n"

--- a/vagrant/check_patroni.sh
+++ b/vagrant/check_patroni.sh
@@ -7,7 +7,7 @@ fi
 
 echo "-- Running patroni checks using endpoint $1"
 echo "-- Cluster checks"
-check_patroni -e "$1" cluster_config_has_changed --state-file cluster.sate_file --save
+check_patroni -e "$1" cluster_config_has_changed --state-file cluster.state_file --save
 check_patroni -e "$1" cluster_has_leader
 check_patroni -e "$1" cluster_has_replica
 check_patroni -e "$1" cluster_is_in_maintenance
@@ -20,5 +20,5 @@ check_patroni -e "$1" node_is_primary
 check_patroni -e "$1" node_is_leader --is-standby-leader
 check_patroni -e "$1" node_is_replica
 check_patroni -e "$1" node_is_replica --is-sync
-check_patroni -e "$1" node_patroni_version --patroni-version 3.1.0
-check_patroni -e "$1" node_tl_has_changed --state-file cluster.sate_file --save
+check_patroni -e "$1" node_patroni_version --patroni-version 4.0.2
+check_patroni -e "$1" node_tl_has_changed --state-file cluster.state_file --save


### PR DESCRIPTION
In this version of patroni :

* Patroni role is written to DCS as primary instead of master.
* Patroni role returned by Patroni REST API has been changed from master to primary.

Update tests and documentation to reflect this.