### PR TITLE
Remove test for 3.7 & 3.8 and add up to 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: "3.7"
-          - python: "3.11"
+          - python: "3.9"
+          - python: "3.13"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # the versions specified here are overridden by github workflow
-envlist = lint, mypy, py{37,38,39,310,311}
+envlist = lint, mypy, py{39,310,311,312,313}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Github complains where it runs the tests:

```
Run actions/setup-python@v2
Version 3.7 was not found in the local cache
Error: Version 3.7 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

3.7 reached eol, 3.8 will soon.
3.12 and 3.13 were not tested.

Fix #74