### PR TITLE
Release V2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-## Unreleased
+## check_patroni 2.1.0 - 2024-10-19
 
 ### Fixed
 

--- a/check_patroni/__init__.py
+++ b/check_patroni/__init__.py
@@ -1,5 +1,5 @@
 import logging
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 _log: logging.Logger = logging.getLogger(__name__)


### PR DESCRIPTION
## check_patroni 2.1.0 - 2024-10-19

### Fixed

* cluster_has_replica now properly accounts for standby leaders (#72, reported by @MLyssens)

### Misc

* Update the tests and the documentation to reflect that master is replaced by
  primary everywhere it's visible in Patroni. We didn't use the term so there
  is nothing to change in our code.